### PR TITLE
add session level traces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# IDE files
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,29 @@ var tracer opentracing.Tracer = ...
 
 // Optionally set Tracer as global 
 opentracing.SetGlobalTracer(tracer)
+```
 
+Add traces for all clients using same session:
+```
+// Create AWS Session
+sess := session.NewSession(...)
+
+// Add OpenTracing handlers using global tracer
+AddOTHandlersToSession(sess)
+
+// Or specify tracer explicitly
+AddOTHandlersToSession(sess, WithTracer(tracer))
+
+// Create AWS service client e.g. DynamoDB client
+dbCient := dynamodb.New(sess)
+
+// Call AWS client
+result, err := dbClient.ListTables(&dynamodb.ListTablesInput{})
+
+```
+
+Add traces to specific client instance:
+```
 // Create AWS Session
 sess := session.NewSession(...)
 
@@ -33,10 +55,10 @@ sess := session.NewSession(...)
 dbCient := dynamodb.New(sess)
 
 // Add OpenTracing handlers using global tracer
-AddOTHandlers(dbClient.Client)
+AddOTHandlersToClient(dbClient.Client)
 
 // Or specify tracer explicitly
-AddOTHandlers(dbClient.Client, WithTracer(tracer))
+AddOTHandlersToClient(dbClient.Client, WithTracer(tracer))
 
 // Call AWS client
 result, err := dbClient.ListTables(&dynamodb.ListTablesInput{})

--- a/handler.go
+++ b/handler.go
@@ -1,6 +1,7 @@
 package otaws
 
 import (
+	"github.com/aws/aws-sdk-go/aws/session"
 	"net/http"
 
 	"github.com/aws/aws-sdk-go/aws/client"
@@ -10,14 +11,32 @@ import (
 	"github.com/opentracing/opentracing-go/log"
 )
 
+// AddOTHandlers adds open tracing handlers to aws client
+//
+// Deprecated: use AddOTHandlersToClient instead
 func AddOTHandlers(cl *client.Client, opts ...Option) {
+	addOTHandlers(&cl.Handlers, opts...)
+}
+
+// AddOTHandlersToClient adds open tracing handlers to aws client
+func AddOTHandlersToClient(cl *client.Client, opts ...Option) {
+	addOTHandlers(&cl.Handlers, opts...)
+}
+
+// AddOTHandlersToSession adds open tracing handlers to aws session.
+// Open tracing handlers will be propagated to all clients using this session.
+func AddOTHandlersToSession(sess *session.Session, opts ...Option) {
+	addOTHandlers(&sess.Handlers, opts...)
+}
+
+func addOTHandlers(h *request.Handlers, opts ...Option) {
 	c := defaultConfig()
 	for _, opt := range opts {
 		opt(c)
 	}
 
 	handler := otHandler(c)
-	cl.Handlers.Build.PushFront(handler)
+	h.Build.PushFront(handler)
 }
 
 func otHandler(c *config) func(*request.Request) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -22,7 +22,7 @@ func TestNonGlobalTracer(t *testing.T) {
 		Region: aws.String("us-west-2"),
 	})
 
-	AddOTHandlers(client, WithTracer(tracer))
+	AddOTHandlersToClient(client, WithTracer(tracer))
 
 	req := client.NewRequest(&request.Operation{
 		Name:       "Test Operation",
@@ -55,7 +55,7 @@ func TestAWS(t *testing.T) {
 		Region: aws.String("us-west-2"),
 	})
 
-	AddOTHandlers(client)
+	AddOTHandlersToClient(client)
 
 	req := client.NewRequest(&request.Operation{
 		Name:       "Test Operation",
@@ -120,7 +120,7 @@ func TestNilResponse(t *testing.T) {
 
 	dbClient := dynamodb.New(sess)
 
-	AddOTHandlers(dbClient.Client)
+	AddOTHandlersToClient(dbClient.Client)
 
 	_, err = dbClient.ListTables(&dynamodb.ListTablesInput{})
 	if err == nil {


### PR DESCRIPTION
It's possible to add handlers on an aws session level.
In my code I'm using singleton session and multiple clients - so it's more convenient for me to use it this way.